### PR TITLE
Update run-me-on-vm-host.sh

### DIFF
--- a/run-me-on-vm-host.sh
+++ b/run-me-on-vm-host.sh
@@ -2,8 +2,8 @@
 
 check_preconditions() {
     echo "Checking preconditions..."
-    AP="$1/AP-Linux-V.4.0.iso"
-
+    AP="$1"
+    
     if [ ! uuid ]; then 
         echo "UUID binary not installed"
         return 1


### PR DESCRIPTION
Consider accepting path with an Alternative .iso Name instead of a hard coded  "AP-Linux-V.4.0.iso"
I tend to give the ISOs timestamps in the naming during the creation process.