### PR TITLE
Update nlhook

### DIFF
--- a/hook/nlhook
+++ b/hook/nlhook
@@ -35,7 +35,7 @@ set_up() {
 
 try_update_from_network() {
     echo "Try update from network..."
-    if wget http://${IP}:8000/update.tar --timeout=3 -O /nloverlay/update-scratch/update.tar; then
+    if wget http://${IP}:8000/update.tar --timeout=5 -O /nloverlay/update-scratch/update.tar; then
         if try_apply_update; then
             echo "Try update from network done."
             return 0


### PR DESCRIPTION
setting --timeout to 5 instead of 3 leads to guaranteed update fetch from BBB via wget, once the SimpleHTTPServer is online 
(50/50 and 100/100 successful tries)